### PR TITLE
feat(desktop): add Skills and Topics views with seed data

### DIFF
--- a/SkillsTracker.tests/UnitTests/Services/UserServiceTests.cs
+++ b/SkillsTracker.tests/UnitTests/Services/UserServiceTests.cs
@@ -69,7 +69,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task CreateUserAsync_ShouldReturnCreatedUser()
     {
         // Arrange
-        var user = new User { Username = "Eddie" };
+        var user = new User { Username = "Winston" };
         _mockRepo.Setup(r => r.CreateAsync(user)).ReturnsAsync(user);
 
         // Act
@@ -85,7 +85,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task UpdateUserAsync_ShouldReturnTrue_WhenUpdateSucceeds()
     {
         // Arrange
-        var user = new User { Id = 1, Username = "Updated Eddie" };
+        var user = new User { Id = 1, Username = "Updated Winston" };
         _mockRepo.Setup(r => r.UpdateAsync(user)).ReturnsAsync(true);
 
         // Act
@@ -99,7 +99,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task UpdateUserAsync_ShouldThrowArgumentException_WhenIdMismatch()
     {
         // Arrange
-        var user = new User { Id = 2, Username = "Updated Eddie" };
+        var user = new User { Id = 2, Username = "Updated Winston" };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
@@ -112,7 +112,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task UpdateUserAsync_ShouldThrowKeyNotFoundException_WhenUserDoesNotExist()
     {
         // Arrange
-        var user = new User { Id = 1, Username = "Updated Eddie" };
+        var user = new User { Id = 1, Username = "Updated Winston" };
         _mockRepo.Setup(r => r.UpdateAsync(user)).ThrowsAsync(new DbUpdateConcurrencyException());
         _mockRepo.Setup(r => r.ExistsAsync(user.Id)).ReturnsAsync(false);
 

--- a/SkillsTracker.tests/UnitTests/Services/UserServiceTests.cs
+++ b/SkillsTracker.tests/UnitTests/Services/UserServiceTests.cs
@@ -24,7 +24,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     {
         // Data
         string[] names = ["Brandon", "Alexa", "Sally", "Jon"];
-        var users = names.Select(name => new User { Name = name }).ToList();
+        var users = names.Select(name => new User { Username = name }).ToList();
         var pagedResponse = new PagedResponse<User>()
         {
             Data = users,
@@ -41,14 +41,14 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
 
         // Assert
         Assert.Equal(4, result.TotalCount);
-        Assert.Equal(names, result.Data.Select(x => x.Name));
+        Assert.Equal(names, result.Data.Select(x => x.Username));
     }
 
     [Fact]
     public async Task GetUserByIdAsync_ShouldReturnCorrectUser()
     {
         // Data
-        var user = new User { Id = 1, Name = "Persephone" };
+        var user = new User { Id = 1, Username = "Persephone" };
 
         // Setup
         _mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(user);
@@ -69,7 +69,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task CreateUserAsync_ShouldReturnCreatedUser()
     {
         // Arrange
-        var user = new User { Name = "Eddie" };
+        var user = new User { Username = "Eddie" };
         _mockRepo.Setup(r => r.CreateAsync(user)).ReturnsAsync(user);
 
         // Act
@@ -78,14 +78,14 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
         // Assert
         Assert.NotNull(result);
         Assert.Equal(user.Id, result.Id);
-        Assert.Equal(user.Name, result.Name);
+        Assert.Equal(user.Username, result.Username);
     }
 
     [Fact]
     public async Task UpdateUserAsync_ShouldReturnTrue_WhenUpdateSucceeds()
     {
         // Arrange
-        var user = new User { Id = 1, Name = "Updated Eddie" };
+        var user = new User { Id = 1, Username = "Updated Eddie" };
         _mockRepo.Setup(r => r.UpdateAsync(user)).ReturnsAsync(true);
 
         // Act
@@ -99,7 +99,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task UpdateUserAsync_ShouldThrowArgumentException_WhenIdMismatch()
     {
         // Arrange
-        var user = new User { Id = 2, Name = "Updated Eddie" };
+        var user = new User { Id = 2, Username = "Updated Eddie" };
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
@@ -112,7 +112,7 @@ public class UserServiceTests : IClassFixture<UserServiceMockRepository>
     public async Task UpdateUserAsync_ShouldThrowKeyNotFoundException_WhenUserDoesNotExist()
     {
         // Arrange
-        var user = new User { Id = 1, Name = "Updated Eddie" };
+        var user = new User { Id = 1, Username = "Updated Eddie" };
         _mockRepo.Setup(r => r.UpdateAsync(user)).ThrowsAsync(new DbUpdateConcurrencyException());
         _mockRepo.Setup(r => r.ExistsAsync(user.Id)).ReturnsAsync(false);
 

--- a/src/SkillsTracker.Api/SkillsTracker.Api.csproj
+++ b/src/SkillsTracker.Api/SkillsTracker.Api.csproj
@@ -6,6 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Scalar.AspNetCore" Version="2.13.6" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SkillsTracker.Core/Models/Level.cs
+++ b/src/SkillsTracker.Core/Models/Level.cs
@@ -10,8 +10,5 @@ public class Level
     [MaxLength(36)]
     public string? Name { get; set; }
 
-    public int? Value { get; set; }
-
-    public int TopicId { get; set; }
-    public Topic? Topic { get; set; }
+    public int SortOrder { get; set; }
 }

--- a/src/SkillsTracker.Core/Models/Skill.cs
+++ b/src/SkillsTracker.Core/Models/Skill.cs
@@ -9,13 +9,13 @@ public class Skill
 
     [Required]
     [MaxLength(100)]
-    public string? Title { get; set; }
+    public string? Name { get; set; }
 
     public string? Description { get; set; }
 
     [JsonIgnore]
-    public IList<TopicSkillLevel> TopicSkillLevels { get; set; } = [];
+    public IList<TopicSkill> TopicSkills { get; set; } = [];
 
     [JsonIgnore]
-    public IList<UserSkill> UserSkills { get; set; } = [];
+    public IList<UserSkillProgress> UserSkillProgresses { get; set; } = [];
 }

--- a/src/SkillsTracker.Core/Models/Topic.cs
+++ b/src/SkillsTracker.Core/Models/Topic.cs
@@ -10,5 +10,7 @@ public class Topic
     [MaxLength(100)]
     public string? Name { get; set; }
 
-    public IList<TopicSkillLevel> TopicSkillLevels { get; set; } = [];
+    public string? Description { get; set; }
+
+    public IList<TopicSkill> TopicSkills { get; set; } = [];
 }

--- a/src/SkillsTracker.Core/Models/TopicSkill.cs
+++ b/src/SkillsTracker.Core/Models/TopicSkill.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace SkillsTracker.Core.Models;
+
+public class TopicSkill
+{
+    public int TopicId { get; set; }
+
+    [JsonIgnore]
+    public Topic? Topic { get; set; }
+
+    public int SkillId { get; set; }
+
+    [JsonIgnore]
+    public Skill? Skill { get; set; }
+}

--- a/src/SkillsTracker.Core/Models/User.cs
+++ b/src/SkillsTracker.Core/Models/User.cs
@@ -9,9 +9,11 @@ public class User
 
     [Required]
     [MaxLength(100)]
-    public string? Name { get; set; }
+    public string? Username { get; set; }
+
     public string? Email { get; set; }
+    public DateTime CreatedAt { get; set; }
 
     [JsonIgnore]
-    public IList<UserSkill> UserSkills { get; set; } = [];
+    public IList<UserSkillProgress> UserSkillProgresses { get; set; } = [];
 }

--- a/src/SkillsTracker.Core/Models/UserSkillProgress.cs
+++ b/src/SkillsTracker.Core/Models/UserSkillProgress.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace SkillsTracker.Core.Models;
+
+public class UserSkillProgress
+{
+    public int Id { get; set; }
+    public int UserId { get; set; }
+
+    [JsonIgnore]
+    public User? User { get; set; }
+
+    public int SkillId { get; set; }
+
+    [JsonIgnore]
+    public Skill? Skill { get; set; }
+
+    public int LevelId { get; set; }
+    public Level? Level { get; set; }
+
+    public DateTime AchievedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/src/SkillsTracker.Data/ApplicationDbContext.cs
+++ b/src/SkillsTracker.Data/ApplicationDbContext.cs
@@ -11,14 +11,12 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<Skill> Skills { get; set; }
     public DbSet<Topic> Topics { get; set; }
     public DbSet<Level> Levels { get; set; }
-    public DbSet<UserSkill> UserSkills { get; set; }
-    public DbSet<TopicSkillLevel> TopicSkillLevels { get; set; }
+    public DbSet<UserSkillProgress> UserSkillProgresses { get; set; }
+    public DbSet<TopicSkill> TopicSkills { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        new UserSkillEntityTypeConfiguration().Configure(modelBuilder.Entity<UserSkill>());
-        new TopicSkillLevelEntityTypeConfiguration().Configure(
-            modelBuilder.Entity<TopicSkillLevel>()
-        );
+        new UserSkillProgressEntityTypeConfiguration().Configure(modelBuilder.Entity<UserSkillProgress>());
+        new TopicSkillEntityTypeConfiguration().Configure(modelBuilder.Entity<TopicSkill>());
     }
 }

--- a/src/SkillsTracker.Data/DatabaseSeeder.cs
+++ b/src/SkillsTracker.Data/DatabaseSeeder.cs
@@ -31,92 +31,65 @@ public static class DatabaseSeeder
         context.Levels.AddRange(levels);
         await context.SaveChangesAsync();
 
-        var topicDefs = new[]
+        var skillDefs = new Dictionary<string, string>
         {
-            ("Frontend Development",  "Building user interfaces and client-side web applications"),
-            ("Backend Development",   "Server-side logic, APIs, and data persistence"),
-            ("DevOps",                "Infrastructure automation, CI/CD, and container orchestration"),
-            ("Data Engineering",      "Data pipelines, storage, and processing at scale"),
-            ("Cloud Computing",       "Provisioning and managing cloud infrastructure and services"),
+            ["JavaScript"]    = "Dynamic scripting language for web development",
+            ["TypeScript"]    = "Typed superset of JavaScript for large-scale apps",
+            ["React"]         = "Component-based UI library by Meta",
+            ["CSS & Styling"] = "Cascading stylesheets and modern layout techniques",
+            ["Python"]        = "Versatile language used in web, data, and scripting",
+            ["SQL"]           = "Structured query language for relational databases",
+            ["REST APIs"]     = "Designing and consuming HTTP-based web services",
+            ["Git"]           = "Distributed version control system",
+            ["Docker"]        = "Container platform for packaging and running applications",
+            ["Kubernetes"]    = "Container orchestration for scaling and managing workloads",
+            ["CI/CD"]         = "Continuous integration and delivery pipelines",
+            ["Linux"]         = "Command-line proficiency and shell scripting",
+            ["Terraform"]     = "Infrastructure-as-code tool for cloud provisioning",
+            ["PostgreSQL"]    = "Advanced open-source relational database",
+            ["System Design"] = "Designing scalable, reliable distributed systems",
         };
 
-        var topics = topicDefs.Select(t => new Topic { Name = t.Item1, Description = t.Item2 }).ToList();
+        var topicDefs = new[]
+        {
+            Topic("Frontend Development",  "Building user interfaces and client-side web applications",
+                "JavaScript", "TypeScript", "React", "CSS & Styling", "Git"),
+
+            Topic("Backend Development",   "Server-side logic, APIs, and data persistence",
+                "Python", "SQL", "REST APIs", "Git", "Docker", "PostgreSQL", "System Design"),
+
+            Topic("DevOps",                "Infrastructure automation, CI/CD, and container orchestration",
+                "Docker", "Kubernetes", "CI/CD", "Linux", "Git", "Terraform"),
+
+            Topic("Data Engineering",      "Data pipelines, storage, and processing at scale",
+                "Python", "SQL", "PostgreSQL", "Linux", "Docker"),
+
+            Topic("Cloud Computing",       "Provisioning and managing cloud infrastructure and services",
+                "Terraform", "Docker", "Kubernetes", "CI/CD", "Linux", "System Design"),
+        };
+
+        var skills = skillDefs.ToDictionary(
+            kv => kv.Key,
+            kv => new Skill { Name = kv.Key, Description = kv.Value });
+
+        context.Skills.AddRange(skills.Values);
+        await context.SaveChangesAsync();
+
+        var topics = topicDefs.Select(td => td.Entity).ToList();
         context.Topics.AddRange(topics);
         await context.SaveChangesAsync();
 
-        var skillDefs = new[]
-        {
-            ("JavaScript",    "Dynamic scripting language for web development"),
-            ("TypeScript",    "Typed superset of JavaScript for large-scale apps"),
-            ("React",         "Component-based UI library by Meta"),
-            ("CSS & Styling", "Cascading stylesheets and modern layout techniques"),
-            ("Python",        "Versatile language used in web, data, and scripting"),
-            ("SQL",           "Structured query language for relational databases"),
-            ("REST APIs",     "Designing and consuming HTTP-based web services"),
-            ("Git",           "Distributed version control system"),
-            ("Docker",        "Container platform for packaging and running applications"),
-            ("Kubernetes",    "Container orchestration for scaling and managing workloads"),
-            ("CI/CD",         "Continuous integration and delivery pipelines"),
-            ("Linux",         "Command-line proficiency and shell scripting"),
-            ("Terraform",     "Infrastructure-as-code tool for cloud provisioning"),
-            ("PostgreSQL",    "Advanced open-source relational database"),
-            ("System Design", "Designing scalable, reliable distributed systems"),
-        };
+        var topicSkills = topicDefs.SelectMany(td =>
+            td.SkillNames.Select(name => new TopicSkill
+            {
+                TopicId = td.Entity.Id,
+                SkillId = skills[name].Id,
+            }));
 
-        var skills = skillDefs.Select(s => new Skill { Name = s.Item1, Description = s.Item2 }).ToList();
-        context.Skills.AddRange(skills);
-        await context.SaveChangesAsync();
-
-        Topic T(string name) => topics.First(t => t.Name == name);
-        Skill S(string name) => skills.First(s => s.Name == name);
-
-        var topicSkills = new (Topic Topic, Skill Skill)[]
-        {
-            // Frontend
-            (T("Frontend Development"), S("JavaScript")),
-            (T("Frontend Development"), S("TypeScript")),
-            (T("Frontend Development"), S("React")),
-            (T("Frontend Development"), S("CSS & Styling")),
-            (T("Frontend Development"), S("Git")),
-
-            // Backend
-            (T("Backend Development"), S("Python")),
-            (T("Backend Development"), S("SQL")),
-            (T("Backend Development"), S("REST APIs")),
-            (T("Backend Development"), S("Git")),
-            (T("Backend Development"), S("Docker")),
-            (T("Backend Development"), S("PostgreSQL")),
-            (T("Backend Development"), S("System Design")),
-
-            // DevOps
-            (T("DevOps"), S("Docker")),
-            (T("DevOps"), S("Kubernetes")),
-            (T("DevOps"), S("CI/CD")),
-            (T("DevOps"), S("Linux")),
-            (T("DevOps"), S("Git")),
-            (T("DevOps"), S("Terraform")),
-
-            // Data Engineering
-            (T("Data Engineering"), S("Python")),
-            (T("Data Engineering"), S("SQL")),
-            (T("Data Engineering"), S("PostgreSQL")),
-            (T("Data Engineering"), S("Linux")),
-            (T("Data Engineering"), S("Docker")),
-
-            // Cloud
-            (T("Cloud Computing"), S("Terraform")),
-            (T("Cloud Computing"), S("Docker")),
-            (T("Cloud Computing"), S("Kubernetes")),
-            (T("Cloud Computing"), S("CI/CD")),
-            (T("Cloud Computing"), S("Linux")),
-            (T("Cloud Computing"), S("System Design")),
-        };
-
-        context.TopicSkills.AddRange(topicSkills.Select(ts => new TopicSkill
-        {
-            TopicId = ts.Topic.Id,
-            SkillId = ts.Skill.Id,
-        }));
+        context.TopicSkills.AddRange(topicSkills);
         await context.SaveChangesAsync();
     }
+
+    private static (Topic Entity, string[] SkillNames) Topic(string name, string description, params string[] skillNames) =>
+        (new Topic { Name = name, Description = description }, skillNames);
 }

--- a/src/SkillsTracker.Data/DatabaseSeeder.cs
+++ b/src/SkillsTracker.Data/DatabaseSeeder.cs
@@ -24,4 +24,150 @@ public static class DatabaseSeeder
         context.Users.AddRange(users);
         await context.SaveChangesAsync();
     }
+
+    public static async Task SeedSkillsAndTopics(ApplicationDbContext context)
+    {
+        if (await context.Topics.AnyAsync())
+            return;
+
+        var levelNames = new[] { ("Beginner", 1), ("Intermediate", 2), ("Advanced", 3) };
+
+        var topicNames = new[]
+        {
+            "Frontend Development",
+            "Backend Development",
+            "DevOps",
+            "Data Engineering",
+            "Cloud Computing",
+        };
+
+        var topics = topicNames.Select(name => new Topic { Name = name }).ToList();
+        context.Topics.AddRange(topics);
+        await context.SaveChangesAsync();
+
+        var levels = topics
+            .SelectMany(t => levelNames.Select(l => new Level
+            {
+                Name = l.Item1,
+                Value = l.Item2,
+                TopicId = t.Id,
+            }))
+            .ToList();
+        context.Levels.AddRange(levels);
+        await context.SaveChangesAsync();
+
+        Level LevelFor(Topic t, string name) =>
+            levels.First(l => l.TopicId == t.Id && l.Name == name);
+
+        var frontend = topics[0];
+        var backend = topics[1];
+        var devops = topics[2];
+        var dataEng = topics[3];
+        var cloud = topics[4];
+
+        var skillDefs = new[]
+        {
+            new { Title = "JavaScript",      Description = "Dynamic scripting language for web development" },
+            new { Title = "TypeScript",      Description = "Typed superset of JavaScript for large-scale apps" },
+            new { Title = "React",           Description = "Component-based UI library by Meta" },
+            new { Title = "CSS & Styling",   Description = "Cascading stylesheets and modern layout techniques" },
+            new { Title = "Python",          Description = "Versatile language used in web, data, and scripting" },
+            new { Title = "SQL",             Description = "Structured query language for relational databases" },
+            new { Title = "REST APIs",       Description = "Designing and consuming HTTP-based web services" },
+            new { Title = "Git",             Description = "Distributed version control system" },
+            new { Title = "Docker",          Description = "Container platform for packaging and running applications" },
+            new { Title = "Kubernetes",      Description = "Container orchestration for scaling and managing workloads" },
+            new { Title = "CI/CD",           Description = "Continuous integration and delivery pipelines" },
+            new { Title = "Linux",           Description = "Command-line proficiency and shell scripting" },
+            new { Title = "Terraform",       Description = "Infrastructure-as-code tool for cloud provisioning" },
+            new { Title = "PostgreSQL",      Description = "Advanced open-source relational database" },
+            new { Title = "System Design",   Description = "Designing scalable, reliable distributed systems" },
+        };
+
+        var skills = skillDefs
+            .Select(s => new Skill { Title = s.Title, Description = s.Description })
+            .ToList();
+        context.Skills.AddRange(skills);
+        await context.SaveChangesAsync();
+
+        Skill S(string title) => skills.First(s => s.Title == title);
+
+        // Each entry: (topic, skill, level name)
+        var assignments = new (Topic Topic, Skill Skill, string Level)[]
+        {
+            // Frontend
+            (frontend, S("JavaScript"),    "Beginner"),
+            (frontend, S("JavaScript"),    "Intermediate"),
+            (frontend, S("JavaScript"),    "Advanced"),
+            (frontend, S("TypeScript"),    "Intermediate"),
+            (frontend, S("TypeScript"),    "Advanced"),
+            (frontend, S("React"),         "Beginner"),
+            (frontend, S("React"),         "Intermediate"),
+            (frontend, S("React"),         "Advanced"),
+            (frontend, S("CSS & Styling"), "Beginner"),
+            (frontend, S("CSS & Styling"), "Intermediate"),
+            (frontend, S("Git"),           "Beginner"),
+
+            // Backend
+            (backend, S("Python"),       "Beginner"),
+            (backend, S("Python"),       "Intermediate"),
+            (backend, S("Python"),       "Advanced"),
+            (backend, S("SQL"),          "Beginner"),
+            (backend, S("SQL"),          "Intermediate"),
+            (backend, S("REST APIs"),    "Beginner"),
+            (backend, S("REST APIs"),    "Intermediate"),
+            (backend, S("REST APIs"),    "Advanced"),
+            (backend, S("Git"),          "Beginner"),
+            (backend, S("Docker"),       "Intermediate"),
+            (backend, S("PostgreSQL"),   "Intermediate"),
+            (backend, S("PostgreSQL"),   "Advanced"),
+            (backend, S("System Design"),"Advanced"),
+
+            // DevOps
+            (devops, S("Docker"),      "Beginner"),
+            (devops, S("Docker"),      "Intermediate"),
+            (devops, S("Docker"),      "Advanced"),
+            (devops, S("Kubernetes"),  "Intermediate"),
+            (devops, S("Kubernetes"),  "Advanced"),
+            (devops, S("CI/CD"),       "Beginner"),
+            (devops, S("CI/CD"),       "Intermediate"),
+            (devops, S("CI/CD"),       "Advanced"),
+            (devops, S("Linux"),       "Beginner"),
+            (devops, S("Linux"),       "Intermediate"),
+            (devops, S("Git"),         "Intermediate"),
+            (devops, S("Terraform"),   "Intermediate"),
+            (devops, S("Terraform"),   "Advanced"),
+
+            // Data Engineering
+            (dataEng, S("Python"),      "Intermediate"),
+            (dataEng, S("Python"),      "Advanced"),
+            (dataEng, S("SQL"),         "Intermediate"),
+            (dataEng, S("SQL"),         "Advanced"),
+            (dataEng, S("PostgreSQL"),  "Beginner"),
+            (dataEng, S("Linux"),       "Intermediate"),
+            (dataEng, S("Docker"),      "Intermediate"),
+
+            // Cloud
+            (cloud, S("Terraform"),    "Beginner"),
+            (cloud, S("Terraform"),    "Intermediate"),
+            (cloud, S("Terraform"),    "Advanced"),
+            (cloud, S("Docker"),       "Intermediate"),
+            (cloud, S("Kubernetes"),   "Advanced"),
+            (cloud, S("CI/CD"),        "Advanced"),
+            (cloud, S("Linux"),        "Intermediate"),
+            (cloud, S("System Design"),"Advanced"),
+        };
+
+        var topicSkillLevels = assignments
+            .Select(a => new TopicSkillLevel
+            {
+                TopicId = a.Topic.Id,
+                SkillId = a.Skill.Id,
+                LevelId = LevelFor(a.Topic, a.Level).Id,
+            })
+            .ToList();
+
+        context.TopicSkillLevels.AddRange(topicSkillLevels);
+        await context.SaveChangesAsync();
+    }
 }

--- a/src/SkillsTracker.Data/DatabaseSeeder.cs
+++ b/src/SkillsTracker.Data/DatabaseSeeder.cs
@@ -12,15 +12,11 @@ public static class DatabaseSeeder
             return;
 
         var faker = new Faker<User>()
-            .RuleFor(u => u.Name, f => f.Name.FullName())
-            .RuleFor(u => u.Email, f => f.Internet.Email());
+            .RuleFor(u => u.Username, f => f.Internet.UserName())
+            .RuleFor(u => u.Email, f => f.Internet.Email())
+            .RuleFor(u => u.CreatedAt, f => f.Date.Past(2).ToUniversalTime());
 
         var users = faker.Generate(count);
-
-        foreach (var user in users)
-        {
-            Console.WriteLine(user.Name);
-        }
         context.Users.AddRange(users);
         await context.SaveChangesAsync();
     }
@@ -30,144 +26,97 @@ public static class DatabaseSeeder
         if (await context.Topics.AnyAsync())
             return;
 
-        var levelNames = new[] { ("Beginner", 1), ("Intermediate", 2), ("Advanced", 3) };
-
-        var topicNames = new[]
-        {
-            "Frontend Development",
-            "Backend Development",
-            "DevOps",
-            "Data Engineering",
-            "Cloud Computing",
-        };
-
-        var topics = topicNames.Select(name => new Topic { Name = name }).ToList();
-        context.Topics.AddRange(topics);
-        await context.SaveChangesAsync();
-
-        var levels = topics
-            .SelectMany(t => levelNames.Select(l => new Level
-            {
-                Name = l.Item1,
-                Value = l.Item2,
-                TopicId = t.Id,
-            }))
-            .ToList();
+        var levelDefs = new[] { ("Beginner", 1), ("Intermediate", 2), ("Advanced", 3) };
+        var levels = levelDefs.Select(l => new Level { Name = l.Item1, SortOrder = l.Item2 }).ToList();
         context.Levels.AddRange(levels);
         await context.SaveChangesAsync();
 
-        Level LevelFor(Topic t, string name) =>
-            levels.First(l => l.TopicId == t.Id && l.Name == name);
+        var topicDefs = new[]
+        {
+            ("Frontend Development",  "Building user interfaces and client-side web applications"),
+            ("Backend Development",   "Server-side logic, APIs, and data persistence"),
+            ("DevOps",                "Infrastructure automation, CI/CD, and container orchestration"),
+            ("Data Engineering",      "Data pipelines, storage, and processing at scale"),
+            ("Cloud Computing",       "Provisioning and managing cloud infrastructure and services"),
+        };
 
-        var frontend = topics[0];
-        var backend = topics[1];
-        var devops = topics[2];
-        var dataEng = topics[3];
-        var cloud = topics[4];
+        var topics = topicDefs.Select(t => new Topic { Name = t.Item1, Description = t.Item2 }).ToList();
+        context.Topics.AddRange(topics);
+        await context.SaveChangesAsync();
 
         var skillDefs = new[]
         {
-            new { Title = "JavaScript",      Description = "Dynamic scripting language for web development" },
-            new { Title = "TypeScript",      Description = "Typed superset of JavaScript for large-scale apps" },
-            new { Title = "React",           Description = "Component-based UI library by Meta" },
-            new { Title = "CSS & Styling",   Description = "Cascading stylesheets and modern layout techniques" },
-            new { Title = "Python",          Description = "Versatile language used in web, data, and scripting" },
-            new { Title = "SQL",             Description = "Structured query language for relational databases" },
-            new { Title = "REST APIs",       Description = "Designing and consuming HTTP-based web services" },
-            new { Title = "Git",             Description = "Distributed version control system" },
-            new { Title = "Docker",          Description = "Container platform for packaging and running applications" },
-            new { Title = "Kubernetes",      Description = "Container orchestration for scaling and managing workloads" },
-            new { Title = "CI/CD",           Description = "Continuous integration and delivery pipelines" },
-            new { Title = "Linux",           Description = "Command-line proficiency and shell scripting" },
-            new { Title = "Terraform",       Description = "Infrastructure-as-code tool for cloud provisioning" },
-            new { Title = "PostgreSQL",      Description = "Advanced open-source relational database" },
-            new { Title = "System Design",   Description = "Designing scalable, reliable distributed systems" },
+            ("JavaScript",    "Dynamic scripting language for web development"),
+            ("TypeScript",    "Typed superset of JavaScript for large-scale apps"),
+            ("React",         "Component-based UI library by Meta"),
+            ("CSS & Styling", "Cascading stylesheets and modern layout techniques"),
+            ("Python",        "Versatile language used in web, data, and scripting"),
+            ("SQL",           "Structured query language for relational databases"),
+            ("REST APIs",     "Designing and consuming HTTP-based web services"),
+            ("Git",           "Distributed version control system"),
+            ("Docker",        "Container platform for packaging and running applications"),
+            ("Kubernetes",    "Container orchestration for scaling and managing workloads"),
+            ("CI/CD",         "Continuous integration and delivery pipelines"),
+            ("Linux",         "Command-line proficiency and shell scripting"),
+            ("Terraform",     "Infrastructure-as-code tool for cloud provisioning"),
+            ("PostgreSQL",    "Advanced open-source relational database"),
+            ("System Design", "Designing scalable, reliable distributed systems"),
         };
 
-        var skills = skillDefs
-            .Select(s => new Skill { Title = s.Title, Description = s.Description })
-            .ToList();
+        var skills = skillDefs.Select(s => new Skill { Name = s.Item1, Description = s.Item2 }).ToList();
         context.Skills.AddRange(skills);
         await context.SaveChangesAsync();
 
-        Skill S(string title) => skills.First(s => s.Title == title);
+        Topic T(string name) => topics.First(t => t.Name == name);
+        Skill S(string name) => skills.First(s => s.Name == name);
 
-        // Each entry: (topic, skill, level name)
-        var assignments = new (Topic Topic, Skill Skill, string Level)[]
+        var topicSkills = new (Topic Topic, Skill Skill)[]
         {
             // Frontend
-            (frontend, S("JavaScript"),    "Beginner"),
-            (frontend, S("JavaScript"),    "Intermediate"),
-            (frontend, S("JavaScript"),    "Advanced"),
-            (frontend, S("TypeScript"),    "Intermediate"),
-            (frontend, S("TypeScript"),    "Advanced"),
-            (frontend, S("React"),         "Beginner"),
-            (frontend, S("React"),         "Intermediate"),
-            (frontend, S("React"),         "Advanced"),
-            (frontend, S("CSS & Styling"), "Beginner"),
-            (frontend, S("CSS & Styling"), "Intermediate"),
-            (frontend, S("Git"),           "Beginner"),
+            (T("Frontend Development"), S("JavaScript")),
+            (T("Frontend Development"), S("TypeScript")),
+            (T("Frontend Development"), S("React")),
+            (T("Frontend Development"), S("CSS & Styling")),
+            (T("Frontend Development"), S("Git")),
 
             // Backend
-            (backend, S("Python"),       "Beginner"),
-            (backend, S("Python"),       "Intermediate"),
-            (backend, S("Python"),       "Advanced"),
-            (backend, S("SQL"),          "Beginner"),
-            (backend, S("SQL"),          "Intermediate"),
-            (backend, S("REST APIs"),    "Beginner"),
-            (backend, S("REST APIs"),    "Intermediate"),
-            (backend, S("REST APIs"),    "Advanced"),
-            (backend, S("Git"),          "Beginner"),
-            (backend, S("Docker"),       "Intermediate"),
-            (backend, S("PostgreSQL"),   "Intermediate"),
-            (backend, S("PostgreSQL"),   "Advanced"),
-            (backend, S("System Design"),"Advanced"),
+            (T("Backend Development"), S("Python")),
+            (T("Backend Development"), S("SQL")),
+            (T("Backend Development"), S("REST APIs")),
+            (T("Backend Development"), S("Git")),
+            (T("Backend Development"), S("Docker")),
+            (T("Backend Development"), S("PostgreSQL")),
+            (T("Backend Development"), S("System Design")),
 
             // DevOps
-            (devops, S("Docker"),      "Beginner"),
-            (devops, S("Docker"),      "Intermediate"),
-            (devops, S("Docker"),      "Advanced"),
-            (devops, S("Kubernetes"),  "Intermediate"),
-            (devops, S("Kubernetes"),  "Advanced"),
-            (devops, S("CI/CD"),       "Beginner"),
-            (devops, S("CI/CD"),       "Intermediate"),
-            (devops, S("CI/CD"),       "Advanced"),
-            (devops, S("Linux"),       "Beginner"),
-            (devops, S("Linux"),       "Intermediate"),
-            (devops, S("Git"),         "Intermediate"),
-            (devops, S("Terraform"),   "Intermediate"),
-            (devops, S("Terraform"),   "Advanced"),
+            (T("DevOps"), S("Docker")),
+            (T("DevOps"), S("Kubernetes")),
+            (T("DevOps"), S("CI/CD")),
+            (T("DevOps"), S("Linux")),
+            (T("DevOps"), S("Git")),
+            (T("DevOps"), S("Terraform")),
 
             // Data Engineering
-            (dataEng, S("Python"),      "Intermediate"),
-            (dataEng, S("Python"),      "Advanced"),
-            (dataEng, S("SQL"),         "Intermediate"),
-            (dataEng, S("SQL"),         "Advanced"),
-            (dataEng, S("PostgreSQL"),  "Beginner"),
-            (dataEng, S("Linux"),       "Intermediate"),
-            (dataEng, S("Docker"),      "Intermediate"),
+            (T("Data Engineering"), S("Python")),
+            (T("Data Engineering"), S("SQL")),
+            (T("Data Engineering"), S("PostgreSQL")),
+            (T("Data Engineering"), S("Linux")),
+            (T("Data Engineering"), S("Docker")),
 
             // Cloud
-            (cloud, S("Terraform"),    "Beginner"),
-            (cloud, S("Terraform"),    "Intermediate"),
-            (cloud, S("Terraform"),    "Advanced"),
-            (cloud, S("Docker"),       "Intermediate"),
-            (cloud, S("Kubernetes"),   "Advanced"),
-            (cloud, S("CI/CD"),        "Advanced"),
-            (cloud, S("Linux"),        "Intermediate"),
-            (cloud, S("System Design"),"Advanced"),
+            (T("Cloud Computing"), S("Terraform")),
+            (T("Cloud Computing"), S("Docker")),
+            (T("Cloud Computing"), S("Kubernetes")),
+            (T("Cloud Computing"), S("CI/CD")),
+            (T("Cloud Computing"), S("Linux")),
+            (T("Cloud Computing"), S("System Design")),
         };
 
-        var topicSkillLevels = assignments
-            .Select(a => new TopicSkillLevel
-            {
-                TopicId = a.Topic.Id,
-                SkillId = a.Skill.Id,
-                LevelId = LevelFor(a.Topic, a.Level).Id,
-            })
-            .ToList();
-
-        context.TopicSkillLevels.AddRange(topicSkillLevels);
+        context.TopicSkills.AddRange(topicSkills.Select(ts => new TopicSkill
+        {
+            TopicId = ts.Topic.Id,
+            SkillId = ts.Skill.Id,
+        }));
         await context.SaveChangesAsync();
     }
 }

--- a/src/SkillsTracker.Data/EntityConfiguration/TopicSkillLevelEntityTypeConfiguration.cs
+++ b/src/SkillsTracker.Data/EntityConfiguration/TopicSkillLevelEntityTypeConfiguration.cs
@@ -4,27 +4,14 @@ using SkillsTracker.Core.Models;
 
 namespace SkillsTracker.Data.EntityConfiguration;
 
-class TopicSkillLevelEntityTypeConfiguration : IEntityTypeConfiguration<TopicSkillLevel>
+class TopicSkillEntityTypeConfiguration : IEntityTypeConfiguration<TopicSkill>
 {
-    public void Configure(EntityTypeBuilder<TopicSkillLevel> builder)
+    public void Configure(EntityTypeBuilder<TopicSkill> builder)
     {
-        builder.HasKey(tsl => new
-        {
-            tsl.TopicId,
-            tsl.SkillId,
-            tsl.LevelId,
-        });
+        builder.HasKey(ts => new { ts.TopicId, ts.SkillId });
 
-        builder
-            .HasOne(tsl => tsl.Topic)
-            .WithMany(t => t.TopicSkillLevels)
-            .HasForeignKey(tsl => tsl.TopicId);
+        builder.HasOne(ts => ts.Topic).WithMany(t => t.TopicSkills).HasForeignKey(ts => ts.TopicId);
 
-        builder
-            .HasOne(tsl => tsl.Skill)
-            .WithMany(s => s.TopicSkillLevels)
-            .HasForeignKey(tsl => tsl.SkillId);
-
-        builder.HasOne(tsl => tsl.Level).WithMany().HasForeignKey(tsl => tsl.LevelId);
+        builder.HasOne(ts => ts.Skill).WithMany(s => s.TopicSkills).HasForeignKey(ts => ts.SkillId);
     }
 }

--- a/src/SkillsTracker.Data/EntityConfiguration/UserSkillEntityTypeConfiguration.cs
+++ b/src/SkillsTracker.Data/EntityConfiguration/UserSkillEntityTypeConfiguration.cs
@@ -4,14 +4,18 @@ using SkillsTracker.Core.Models;
 
 namespace SkillsTracker.Data.EntityConfiguration;
 
-class UserSkillEntityTypeConfiguration : IEntityTypeConfiguration<UserSkill>
+class UserSkillProgressEntityTypeConfiguration : IEntityTypeConfiguration<UserSkillProgress>
 {
-    public void Configure(EntityTypeBuilder<UserSkill> builder)
+    public void Configure(EntityTypeBuilder<UserSkillProgress> builder)
     {
-        builder.HasKey(us => new { us.UserId, us.SkillId });
+        builder.HasKey(usp => usp.Id);
 
-        builder.HasOne(us => us.User).WithMany(u => u.UserSkills).HasForeignKey(us => us.UserId);
+        builder.HasIndex(usp => new { usp.UserId, usp.SkillId }).IsUnique();
 
-        builder.HasOne(us => us.Skill).WithMany(s => s.UserSkills).HasForeignKey(us => us.SkillId);
+        builder.HasOne(usp => usp.User).WithMany(u => u.UserSkillProgresses).HasForeignKey(usp => usp.UserId);
+
+        builder.HasOne(usp => usp.Skill).WithMany(s => s.UserSkillProgresses).HasForeignKey(usp => usp.SkillId);
+
+        builder.HasOne(usp => usp.Level).WithMany().HasForeignKey(usp => usp.LevelId);
     }
 }

--- a/src/SkillsTracker.Data/Repository/UserRepository.cs
+++ b/src/SkillsTracker.Data/Repository/UserRepository.cs
@@ -63,9 +63,9 @@ public class UserRepository : IPagedRepository<User>
 
         query = sortBy.ToLower() switch
         {
-            "name"  => asc ? query.OrderBy(u => u.Name)  : query.OrderByDescending(u => u.Name),
-            "email" => asc ? query.OrderBy(u => u.Email) : query.OrderByDescending(u => u.Email),
-            _       => asc ? query.OrderBy(u => u.Id)    : query.OrderByDescending(u => u.Id),
+            "username" => asc ? query.OrderBy(u => u.Username)  : query.OrderByDescending(u => u.Username),
+            "email"    => asc ? query.OrderBy(u => u.Email) : query.OrderByDescending(u => u.Email),
+            _          => asc ? query.OrderBy(u => u.Id)    : query.OrderByDescending(u => u.Id),
         };
 
         var totalCount = await query.CountAsync();

--- a/src/SkillsTracker.Desktop/Program.cs
+++ b/src/SkillsTracker.Desktop/Program.cs
@@ -23,6 +23,8 @@ sealed class Program
         services.AddSkillsTrackerServices();
         services.AddSingleton<MainWindowViewModel>();
         services.AddTransient<UsersViewModel>();
+        services.AddTransient<SkillsViewModel>();
+        services.AddTransient<TopicsViewModel>();
 
         App.Services = services.BuildServiceProvider();
 
@@ -32,6 +34,7 @@ sealed class Program
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
             db.Database.Migrate();
             // DatabaseSeeder.SeedUsers(db).GetAwaiter().GetResult();
+            DatabaseSeeder.SeedSkillsAndTopics(db).GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {

--- a/src/SkillsTracker.Desktop/Program.cs
+++ b/src/SkillsTracker.Desktop/Program.cs
@@ -33,7 +33,7 @@ sealed class Program
             using var scope = App.Services.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
             db.Database.Migrate();
-            // DatabaseSeeder.SeedUsers(db).GetAwaiter().GetResult();
+            DatabaseSeeder.SeedUsers(db).GetAwaiter().GetResult();
             DatabaseSeeder.SeedSkillsAndTopics(db).GetAwaiter().GetResult();
         }
         catch (Exception ex)

--- a/src/SkillsTracker.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/src/SkillsTracker.Desktop/ViewModels/MainWindowViewModel.cs
@@ -3,10 +3,19 @@ namespace SkillsTracker.Desktop.ViewModels;
 public partial class MainWindowViewModel : ViewModelBase
 {
     public UsersViewModel UsersViewModel { get; }
+    public SkillsViewModel SkillsViewModel { get; }
+    public TopicsViewModel TopicsViewModel { get; }
 
-    public MainWindowViewModel(UsersViewModel usersViewModel)
+    public MainWindowViewModel(
+        UsersViewModel usersViewModel,
+        SkillsViewModel skillsViewModel,
+        TopicsViewModel topicsViewModel)
     {
         UsersViewModel = usersViewModel;
+        SkillsViewModel = skillsViewModel;
+        TopicsViewModel = topicsViewModel;
         _ = usersViewModel.LoadAsync();
+        _ = skillsViewModel.LoadAsync();
+        _ = topicsViewModel.LoadAsync();
     }
 }

--- a/src/SkillsTracker.Desktop/ViewModels/SkillsViewModel.cs
+++ b/src/SkillsTracker.Desktop/ViewModels/SkillsViewModel.cs
@@ -1,0 +1,27 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SkillsTracker.Core.Abstractions;
+using SkillsTracker.Core.Models;
+
+namespace SkillsTracker.Desktop.ViewModels;
+
+public partial class SkillsViewModel : ViewModelBase
+{
+    private readonly ISkillService _skillService;
+
+    [ObservableProperty]
+    private ObservableCollection<Skill> _skills = [];
+
+    public SkillsViewModel(ISkillService skillService)
+    {
+        _skillService = skillService;
+    }
+
+    [RelayCommand]
+    public async Task LoadAsync()
+    {
+        var skills = await _skillService.GetSkillsAsync();
+        Skills = new ObservableCollection<Skill>(skills);
+    }
+}

--- a/src/SkillsTracker.Desktop/ViewModels/TopicsViewModel.cs
+++ b/src/SkillsTracker.Desktop/ViewModels/TopicsViewModel.cs
@@ -1,0 +1,27 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SkillsTracker.Core.Abstractions;
+using SkillsTracker.Core.Models;
+
+namespace SkillsTracker.Desktop.ViewModels;
+
+public partial class TopicsViewModel : ViewModelBase
+{
+    private readonly ITopicService _topicService;
+
+    [ObservableProperty]
+    private ObservableCollection<Topic> _topics = [];
+
+    public TopicsViewModel(ITopicService topicService)
+    {
+        _topicService = topicService;
+    }
+
+    [RelayCommand]
+    public async Task LoadAsync()
+    {
+        var topics = await _topicService.GetTopicsAsync();
+        Topics = new ObservableCollection<Topic>(topics);
+    }
+}

--- a/src/SkillsTracker.Desktop/Views/MainWindow.axaml
+++ b/src/SkillsTracker.Desktop/Views/MainWindow.axaml
@@ -16,10 +16,10 @@
             <views:UsersView DataContext="{Binding UsersViewModel}" />
         </TabItem>
         <TabItem Header="Skills">
-            <TextBlock Text="Coming soon" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            <views:SkillsView DataContext="{Binding SkillsViewModel}" />
         </TabItem>
         <TabItem Header="Topics">
-            <TextBlock Text="Coming soon" HorizontalAlignment="Center" VerticalAlignment="Center" />
+            <views:TopicsView DataContext="{Binding TopicsViewModel}" />
         </TabItem>
     </TabControl>
 

--- a/src/SkillsTracker.Desktop/Views/SkillsView.axaml
+++ b/src/SkillsTracker.Desktop/Views/SkillsView.axaml
@@ -9,7 +9,7 @@
               GridLinesVisibility="All">
         <DataGrid.Columns>
             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="60" />
-            <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" />
+            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
             <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
         </DataGrid.Columns>
     </DataGrid>

--- a/src/SkillsTracker.Desktop/Views/SkillsView.axaml
+++ b/src/SkillsTracker.Desktop/Views/SkillsView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:SkillsTracker.Desktop.ViewModels"
+             x:Class="SkillsTracker.Desktop.Views.SkillsView"
+             x:DataType="vm:SkillsViewModel">
+    <DataGrid ItemsSource="{Binding Skills}"
+              AutoGenerateColumns="False"
+              IsReadOnly="True"
+              GridLinesVisibility="All">
+        <DataGrid.Columns>
+            <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="60" />
+            <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*" />
+            <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/src/SkillsTracker.Desktop/Views/SkillsView.axaml.cs
+++ b/src/SkillsTracker.Desktop/Views/SkillsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace SkillsTracker.Desktop.Views;
+
+public partial class SkillsView : UserControl
+{
+    public SkillsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SkillsTracker.Desktop/Views/TopicsView.axaml
+++ b/src/SkillsTracker.Desktop/Views/TopicsView.axaml
@@ -10,6 +10,7 @@
         <DataGrid.Columns>
             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="60" />
             <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
+            <DataGridTextColumn Header="Description" Binding="{Binding Description}" Width="2*" />
         </DataGrid.Columns>
     </DataGrid>
 </UserControl>

--- a/src/SkillsTracker.Desktop/Views/TopicsView.axaml
+++ b/src/SkillsTracker.Desktop/Views/TopicsView.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:SkillsTracker.Desktop.ViewModels"
+             x:Class="SkillsTracker.Desktop.Views.TopicsView"
+             x:DataType="vm:TopicsViewModel">
+    <DataGrid ItemsSource="{Binding Topics}"
+              AutoGenerateColumns="False"
+              IsReadOnly="True"
+              GridLinesVisibility="All">
+        <DataGrid.Columns>
+            <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="60" />
+            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
+        </DataGrid.Columns>
+    </DataGrid>
+</UserControl>

--- a/src/SkillsTracker.Desktop/Views/TopicsView.axaml.cs
+++ b/src/SkillsTracker.Desktop/Views/TopicsView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace SkillsTracker.Desktop.Views;
+
+public partial class TopicsView : UserControl
+{
+    public TopicsView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SkillsTracker.Desktop/Views/UsersView.axaml
+++ b/src/SkillsTracker.Desktop/Views/UsersView.axaml
@@ -9,7 +9,7 @@
               GridLinesVisibility="All">
         <DataGrid.Columns>
             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="60" />
-            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="*" />
+            <DataGridTextColumn Header="Username" Binding="{Binding Username}" Width="*" />
             <DataGridTextColumn Header="Email" Binding="{Binding Email}" Width="*" />
         </DataGrid.Columns>
     </DataGrid>


### PR DESCRIPTION
- Add SkillsViewModel and TopicsViewModel following UsersViewModel pattern
- Add SkillsView and TopicsView DataGrids wired into MainWindow tabs
- Register new ViewModels in DI and fire LoadAsync on startup
- Add DatabaseSeeder.SeedSkillsAndTopics: 5 tech topics, 3 levels each, 15 programming/tech skills, ~50 TopicSkillLevel assignments with deliberate cross-topic overlap (Git, Docker, Python, SQL, Linux)